### PR TITLE
Add function name to errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,21 +15,22 @@ const opts = {
   when: propEq('statusCode', 429)
 }
 
-const inflateError = data => {
-  const err = new Error(data.errorMessage)
-  err.name = data.errorType
-  err.upstreamStack = data.stackTrace
-  return err
-}
+const invoke = FunctionName => {
+  const inflateError = data => {
+    const err = new Error(`[${FunctionName}] ${data.errorMessage}`)
+    err.FunctionName = FunctionName
+    err.name = data.errorType
+    err.upstreamStack = data.stackTrace
+    return err
+  }
 
-const checkError = ifElse(
-  prop('FunctionError'),
-  compose(reject, inflateError, prop('Payload')),
-  prop('Payload')
-)
+  const checkError = ifElse(
+    prop('FunctionError'),
+    compose(reject, inflateError, prop('Payload')),
+    prop('Payload')
+  )
 
-const invoke = FunctionName =>
-  backoff(opts,
+  return backoff(opts,
     pipe(
       JSON.stringify,
       objOf('Payload'),
@@ -44,5 +45,6 @@ const invoke = FunctionName =>
       )
     )
   )
+}
 
 module.exports = invoke

--- a/test.js
+++ b/test.js
@@ -97,7 +97,8 @@ describe('invoke', () => {
     )
 
     it('inflates the upstream error', () => {
-      expect(res().message).to.equal('ruh roh')
+      expect(res().message).to.equal('[my-lambda] ruh roh')
+      expect(res().FunctionName).to.equal('my-lambda')
       expect(res().name).to.equal('SprocketError')
       expect(res().upstreamStack).to.eql([])
     })


### PR DESCRIPTION
![dilbert me in a nutshell](https://i.pinimg.com/originals/ec/10/34/ec10349b66a35cc24ef93581a12e44fe.jpg)

Because it's hard to debug errors in another lambda if you don't know which one it is.