### PR TITLE
Accept instance of Lambda to support custom endpoints

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,8 +31,7 @@
     "eslint": "^4.19.1",
     "mocha": "^5.1.1",
     "nyc": "^11.8.0",
-    "prop-factory": "^1.0.0",
-    "proxyquire": "^2.0.1"
+    "prop-factory": "^1.0.0"
   },
   "peerDependencies": {
     "aws-sdk": "2.x"

--- a/test.js
+++ b/test.js
@@ -1,6 +1,7 @@
-const { always, pick } = require('ramda')
+const { pick }   = require('ramda')
 const { expect } = require('chai')
-const proxyquire = require('proxyquire').noCallThru()
+
+const invoke = require('.')
 
 describe('invoke', () => {
   const input = { foo: 'bar' }
@@ -48,12 +49,10 @@ describe('invoke', () => {
   )
 
   describe('inputs', () => {
-    const invoke = proxyquire('.', {
-      'aws-sdk': { Lambda: always({ invoke: success }) }
-    })
+    const lambda = { invoke: success }
 
     beforeEach(() =>
-      invoke(name)(input)
+      invoke(lambda, name)(input)
     )
 
     it('invokes the specified lambda', () =>
@@ -70,12 +69,10 @@ describe('invoke', () => {
   })
 
   describe('on success', () => {
-    const invoke = proxyquire('.', {
-      'aws-sdk': { Lambda: always({ invoke: success }) }
-    })
+    const lambda = { invoke: success }
 
     beforeEach(() =>
-      invoke(name)(input).then(res)
+      invoke(lambda, name)(input).then(res)
     )
 
     it('parses the output Payload', () =>
@@ -84,12 +81,10 @@ describe('invoke', () => {
   })
 
   describe('on failure', () => {
-    const invoke = proxyquire('.', {
-      'aws-sdk': { Lambda: always({ invoke: failure }) }
-    })
+    const lambda = { invoke: failure }
 
     beforeEach(() =>
-      invoke(name)(input).catch(res)
+      invoke(lambda, name)(input).catch(res)
     )
 
     it('does not backoff', () =>
@@ -105,12 +100,10 @@ describe('invoke', () => {
   })
 
   describe('when concurrency limit reached', () => {
-    const invoke = proxyquire('.', {
-      'aws-sdk': { Lambda: always({ invoke: rateLimit() }) }
-    })
+    const lambda = { invoke: rateLimit() }
 
     beforeEach(() =>
-      invoke(name)(input).then(res)
+      invoke(lambda, name)(input).then(res)
     )
 
     it('backs-off invocations until success', () =>

--- a/yarn.lock
+++ b/yarn.lock
@@ -817,13 +817,6 @@ file-entry-cache@^2.0.0:
     flat-cache "^1.2.1"
     object-assign "^4.0.1"
 
-fill-keys@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/fill-keys/-/fill-keys-1.0.2.tgz#9a8fa36f4e8ad634e3bf6b4f3c8882551452eb20"
-  dependencies:
-    is-object "~1.0.1"
-    merge-descriptors "~1.0.0"
-
 fill-range@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-4.0.0.tgz#d544811d428f98eb06a63dc402d2403c328c38f7"
@@ -1199,10 +1192,6 @@ is-number@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-4.0.0.tgz#0026e37f5454d73e356dfe6564699867c6a7f0ff"
 
-is-object@~1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/is-object/-/is-object-1.0.1.tgz#8952688c5ec2ffd6b03ecc85e769e02903083470"
-
 is-odd@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-odd/-/is-odd-2.0.0.tgz#7646624671fd7ea558ccd9a2795182f2958f1b24"
@@ -1477,10 +1466,6 @@ mem@^1.1.0:
   dependencies:
     mimic-fn "^1.0.0"
 
-merge-descriptors@~1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/merge-descriptors/-/merge-descriptors-1.0.1.tgz#b00aaa556dd8b44568150ec9d1b953f3f90cbb61"
-
 merge-source-map@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/merge-source-map/-/merge-source-map-1.1.0.tgz#2fdde7e6020939f70906a68f2d7ae685e4c8c646"
@@ -1565,10 +1550,6 @@ mocha@^5.1.1:
     minimatch "3.0.4"
     mkdirp "0.5.1"
     supports-color "4.4.0"
-
-module-not-found-error@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/module-not-found-error/-/module-not-found-error-1.0.1.tgz#cf8b4ff4f29640674d6cdd02b0e3bc523c2bbdc0"
 
 ms@2.0.0:
   version "2.0.0"
@@ -1840,14 +1821,6 @@ prop-factory@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/prop-factory/-/prop-factory-1.0.0.tgz#1a1f953b10be675b5524f2273e38dfba18151ae6"
 
-proxyquire@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/proxyquire/-/proxyquire-2.0.1.tgz#958d732be13d21d374cc2256645a5ff97c76a669"
-  dependencies:
-    fill-keys "^1.0.2"
-    module-not-found-error "^1.0.0"
-    resolve "~1.5.0"
-
 pseudomap@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
@@ -1972,12 +1945,6 @@ resolve-from@^2.0.0:
 resolve-url@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
-
-resolve@~1.5.0:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.5.0.tgz#1f09acce796c9a762579f31b2c1cc4c3cddf9f36"
-  dependencies:
-    path-parse "^1.0.5"
 
 restore-cursor@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
![dilbert](http://api.ning.com/files/2a0ON7bWIbeVGCmzZVYQyk1NpM6Uo2CzkdG-AbCFH7Oot*OywHDH*gv9YnCZWYYtTCLa5ZPWf3qIqQMa*TrZPGGSMRDoeyR7/FunnySalesCartoonTrainingILTClassroomTechnologyJokeHumor.gif?width=737)

As we dev on lambda stuffs, it would be great to point at some local endpoint.  So en lieu of `invoke` configuring the `Lambda` instance, this PR introduces a breaking change to let the consumer provide the `Lambda` instance, preconfigured with any custom options.